### PR TITLE
Fix generic assignability check

### DIFF
--- a/StrangeIoC/framework/injector/InjectionBinding.cs
+++ b/StrangeIoC/framework/injector/InjectionBinding.cs
@@ -107,16 +107,18 @@ public class InjectionBinding : Binding, IInjectionBinding
 		return this;
 	}
 
-	protected bool HasGenericAssignableFrom( Type keyType, Type objType )
-	{
-		//FIXME: We need to figure out how to determine generic assignability
-		if( keyType.IsGenericType == false )
-		{
-			return false;
-		}
+       protected bool HasGenericAssignableFrom( Type keyType, Type objType )
+       {
+               if( keyType.IsGenericType == false )
+               {
+                       return false;
+               }
 
-		return true;
-	}
+               //If the key is an open generic type, compare against its definition
+               Type genericDefinition = keyType.IsGenericTypeDefinition ? keyType : keyType.GetGenericTypeDefinition();
+
+               return IsGenericTypeAssignable( objType, genericDefinition );
+       }
 
 	protected bool IsGenericTypeAssignable( Type givenType, Type genericType )
 	{


### PR DESCRIPTION
## Summary
- implement generic assignability logic in `InjectionBinding.HasGenericAssignableFrom`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405b95a58c832481316d37ec1455f6