### PR TITLE
Fix spelling in IPool.cs

### DIFF
--- a/StrangeIoC/framework/pool/IPool.cs
+++ b/StrangeIoC/framework/pool/IPool.cs
@@ -95,7 +95,7 @@ IManagedList
 	/// <summary>
 	/// Gets or sets the size of the pool.
 	/// </summary>
-	/// <value>The pool size. '0' is a special value indicating infinite size. Infinite pools expand as necessary to accomodate requirement.</value>
+       /// <value>The pool size. '0' is a special value indicating infinite size. Infinite pools expand as necessary to accommodate requirement.</value>
 	int size { get; set; }
 
 	/// <summary>


### PR DESCRIPTION
## Summary
- fix typo "accomodate" -> "accommodate" in `IPool.cs`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_68406685ac748324a1f6ea40bc01bf95