### PR TITLE
Add initial C++ port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ sysinfo.txt
 *.gd
 *.gd.meta
 *.orig
+*.vcxproj
+*.vcxproj*
+*.sln

--- a/README_CPP.md
+++ b/README_CPP.md
@@ -1,0 +1,28 @@
+# StrangeIoC C++ Port
+
+This directory contains a minimal C++ adaptation of the original StrangeIoC framework.
+
+## Building (with CMake)
+
+```bash
+mkdir build && cd build
+cmake ../StrangeIoC_CPP
+cmake --build .
+```
+
+Run unit tests:
+
+```bash
+./StrangeIoC_CPP_tests
+```
+
+## Visual Studio
+
+A Visual Studio solution `StrangeIoC_CPP.sln` is provided under `StrangeIoC_CPP/`.
+Open the solution and build the `StrangeIoC_CPP` project.
+
+## Migration Notes
+
+The C++ version mirrors the structure of the C# project but only implements a
+subset of features using modern C++ idioms. Developers accustomed to the C#
+version should port their bindings and signals to the corresponding C++ classes.

--- a/StrangeIoC_CPP/CMakeLists.txt
+++ b/StrangeIoC_CPP/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.10)
+project(StrangeIoC_CPP)
+add_library(StrangeIoC_CPP
+    framework/binding/Binding.cpp
+    framework/binding/Binder.cpp
+)
+target_include_directories(StrangeIoC_CPP PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+add_executable(StrangeIoC_CPP_tests tests/main.cpp)
+target_link_libraries(StrangeIoC_CPP_tests StrangeIoC_CPP)
+enable_testing()
+add_test(NAME StrangeIoC_CPP_tests COMMAND StrangeIoC_CPP_tests)

--- a/StrangeIoC_CPP/LICENSE-2.0.txt
+++ b/StrangeIoC_CPP/LICENSE-2.0.txt
@@ -1,0 +1,176 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+

--- a/StrangeIoC_CPP/NOTICE.txt
+++ b/StrangeIoC_CPP/NOTICE.txt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Andrey Sidorov
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+ 
+/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+ 
+Authors:
+https://github.com/AndreySkyFoxSidorov 
+https://github.com/fogAndWhisky
+https://github.com/WillzZz
+https://github.com/jnbt
+https://github.com/bejeweledpair
+https://github.com/bcjordan
+https://github.com/unitymarc
+https://github.com/noodle
+https://github.com/srimarc

--- a/StrangeIoC_CPP/StrangeIoC_CPP.sln
+++ b/StrangeIoC_CPP/StrangeIoC_CPP.sln
@@ -1,0 +1,15 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{BC8A1FFA-BEE3-4634-8014-F334798102B3}") = "StrangeIoC_CPP", "StrangeIoC_CPP.vcxproj", "{41A96A05-3BF7-43AE-B921-F110B9E3C753}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|x64 = Debug|x64
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{41A96A05-3BF7-43AE-B921-F110B9E3C753}.Debug|x64.ActiveCfg = Debug|x64
+{41A96A05-3BF7-43AE-B921-F110B9E3C753}.Debug|x64.Build.0 = Debug|x64
+EndGlobalSection
+EndGlobal

--- a/StrangeIoC_CPP/StrangeIoC_CPP.vcxproj
+++ b/StrangeIoC_CPP/StrangeIoC_CPP.vcxproj
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClInclude Include="framework/binding/IBinding.h" />
+    <ClInclude Include="framework/binding/Binding.h" />
+    <ClInclude Include="framework/binding/Binder.h" />
+    <ClInclude Include="framework/signal/Signal.h" />
+    <ClInclude Include="framework/injector/Injector.h" />
+    <ClInclude Include="framework/dispatcher/EventDispatcher.h" />
+    <ClInclude Include="Unity/UnityStubs.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="framework/binding/Binding.cpp" />
+    <ClCompile Include="framework/binding/Binder.cpp" />
+  </ItemGroup>
+</Project>

--- a/StrangeIoC_CPP/Unity/UnityStubs.h
+++ b/StrangeIoC_CPP/Unity/UnityStubs.h
@@ -1,0 +1,9 @@
+#ifndef STRANGE_UNITY_STUBS_H
+#define STRANGE_UNITY_STUBS_H
+
+namespace Unity {
+class GameObject {};
+class MonoBehaviour {};
+}
+
+#endif

--- a/StrangeIoC_CPP/framework/binding/Binder.cpp
+++ b/StrangeIoC_CPP/framework/binding/Binder.cpp
@@ -1,0 +1,24 @@
+#include "Binder.h"
+
+namespace strange {
+namespace framework {
+
+std::shared_ptr<Binding> Binder::Bind(const std::string& key) {
+    auto binding = std::make_shared<Binding>();
+    binding->Bind(key);
+    return binding;
+}
+
+void Binder::Register(const Binding& binding) {
+    bindings_[binding.key()] = binding.value();
+}
+
+std::string Binder::Get(const std::string& key) const {
+    auto it = bindings_.find(key);
+    if (it != bindings_.end())
+        return it->second;
+    return std::string();
+}
+
+}
+}

--- a/StrangeIoC_CPP/framework/binding/Binder.h
+++ b/StrangeIoC_CPP/framework/binding/Binder.h
@@ -1,0 +1,24 @@
+#ifndef STRANGE_FRAMEWORK_BINDING_BINDER_H
+#define STRANGE_FRAMEWORK_BINDING_BINDER_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include "Binding.h"
+
+namespace strange {
+namespace framework {
+
+class Binder {
+private:
+    std::unordered_map<std::string, std::string> bindings_;
+public:
+    std::shared_ptr<Binding> Bind(const std::string& key);
+    void Register(const Binding& binding);
+    std::string Get(const std::string& key) const;
+};
+
+}
+}
+
+#endif

--- a/StrangeIoC_CPP/framework/binding/Binding.cpp
+++ b/StrangeIoC_CPP/framework/binding/Binding.cpp
@@ -1,0 +1,17 @@
+#include "Binding.h"
+
+namespace strange {
+namespace framework {
+
+IBinding& Binding::Bind(const std::string& key) {
+    key_ = key;
+    return *this;
+}
+
+IBinding& Binding::To(const std::string& value) {
+    value_ = value;
+    return *this;
+}
+
+}
+}

--- a/StrangeIoC_CPP/framework/binding/Binding.h
+++ b/StrangeIoC_CPP/framework/binding/Binding.h
@@ -1,0 +1,24 @@
+#ifndef STRANGE_FRAMEWORK_BINDING_BINDING_H
+#define STRANGE_FRAMEWORK_BINDING_BINDING_H
+
+#include "IBinding.h"
+
+namespace strange {
+namespace framework {
+
+class Binding : public IBinding {
+private:
+    std::string key_;
+    std::string value_;
+public:
+    Binding() = default;
+    IBinding& Bind(const std::string& key) override;
+    IBinding& To(const std::string& value) override;
+    const std::string& key() const { return key_; }
+    const std::string& value() const { return value_; }
+};
+
+}
+}
+
+#endif

--- a/StrangeIoC_CPP/framework/binding/IBinding.h
+++ b/StrangeIoC_CPP/framework/binding/IBinding.h
@@ -1,0 +1,19 @@
+#ifndef STRANGE_FRAMEWORK_BINDING_IBINDING_H
+#define STRANGE_FRAMEWORK_BINDING_IBINDING_H
+
+#include <string>
+
+namespace strange {
+namespace framework {
+
+class IBinding {
+public:
+    virtual ~IBinding() = default;
+    virtual IBinding& Bind(const std::string& key) = 0;
+    virtual IBinding& To(const std::string& value) = 0;
+};
+
+}
+}
+
+#endif

--- a/StrangeIoC_CPP/framework/dispatcher/EventDispatcher.h
+++ b/StrangeIoC_CPP/framework/dispatcher/EventDispatcher.h
@@ -1,0 +1,33 @@
+#ifndef STRANGE_FRAMEWORK_DISPATCHER_EVENTDISPATCHER_H
+#define STRANGE_FRAMEWORK_DISPATCHER_EVENTDISPATCHER_H
+
+#include <functional>
+#include <unordered_map>
+#include <vector>
+#include <string>
+
+namespace strange {
+namespace framework {
+
+class EventDispatcher {
+public:
+    using Callback = std::function<void()>;
+    void AddListener(const std::string& type, Callback cb) {
+        listeners_[type].push_back(cb);
+    }
+    void Dispatch(const std::string& type) {
+        auto it = listeners_.find(type);
+        if (it != listeners_.end()) {
+            for (auto& cb : it->second) {
+                cb();
+            }
+        }
+    }
+private:
+    std::unordered_map<std::string, std::vector<Callback>> listeners_;
+};
+
+}
+}
+
+#endif

--- a/StrangeIoC_CPP/framework/injector/Injector.h
+++ b/StrangeIoC_CPP/framework/injector/Injector.h
@@ -1,0 +1,37 @@
+#ifndef STRANGE_FRAMEWORK_INJECTOR_INJECTOR_H
+#define STRANGE_FRAMEWORK_INJECTOR_INJECTOR_H
+
+#include <memory>
+#include <unordered_map>
+#include <typeindex>
+#include <functional>
+
+namespace strange {
+namespace framework {
+
+class Injector {
+public:
+    template<typename T>
+    void Bind(std::function<std::shared_ptr<T>()> factory) {
+        creators_[std::type_index(typeid(T))] = [factory]() {
+            return std::static_pointer_cast<void>(factory());
+        };
+    }
+
+    template<typename T>
+    std::shared_ptr<T> Get() {
+        auto it = creators_.find(std::type_index(typeid(T)));
+        if (it != creators_.end()) {
+            return std::static_pointer_cast<T>(it->second());
+        }
+        return nullptr;
+    }
+
+private:
+    std::unordered_map<std::type_index, std::function<std::shared_ptr<void>()>> creators_;
+};
+
+}
+}
+
+#endif

--- a/StrangeIoC_CPP/framework/signal/Signal.h
+++ b/StrangeIoC_CPP/framework/signal/Signal.h
@@ -1,0 +1,27 @@
+#ifndef STRANGE_FRAMEWORK_SIGNAL_SIGNAL_H
+#define STRANGE_FRAMEWORK_SIGNAL_SIGNAL_H
+
+#include <functional>
+#include <vector>
+
+namespace strange {
+namespace framework {
+
+template<typename... Args>
+class Signal {
+public:
+    using Callback = std::function<void(Args...)>;
+    void AddListener(const Callback& cb) { listeners_.push_back(cb); }
+    void Dispatch(Args... args) {
+        for (auto& cb : listeners_) {
+            cb(args...);
+        }
+    }
+private:
+    std::vector<Callback> listeners_;
+};
+
+}
+}
+
+#endif

--- a/StrangeIoC_CPP/tests/main.cpp
+++ b/StrangeIoC_CPP/tests/main.cpp
@@ -1,0 +1,30 @@
+#include <cassert>
+#include "../framework/binding/Binder.h"
+#include "../framework/signal/Signal.h"
+#include "../framework/injector/Injector.h"
+
+using namespace strange::framework;
+
+int main() {
+    // Test Binder
+    Binder binder;
+    auto binding = binder.Bind("test");
+    binding->To("value");
+    binder.Register(*binding);
+    assert(binder.Get("test") == "value");
+
+    // Test Signal
+    Signal<int> sig;
+    int val = 0;
+    sig.AddListener([&](int v){ val = v; });
+    sig.Dispatch(42);
+    assert(val == 42);
+
+    // Test Injector
+    Injector inj;
+    inj.Bind<int>([](){ return std::make_shared<int>(7); });
+    auto instance = inj.Get<int>();
+    assert(instance && *instance == 7);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `.vcxproj` and `.sln` to kick off a Visual Studio build
- port core binding/dispatcher/injector/signal classes to C++
- provide basic CMake build and unit tests
- include minimal Unity stubs
- document build steps in new `README_CPP.md`
- ignore Visual Studio artifacts in `.gitignore`

## Testing
- `cmake ../StrangeIoC_CPP`
- `make`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68406733c5388324a9393b2d35eadac4