### PR TITLE
Enhance C++ port parity

### DIFF
--- a/StrangeIoC_CPP/framework/binding/Binder.cpp
+++ b/StrangeIoC_CPP/framework/binding/Binder.cpp
@@ -20,5 +20,9 @@ std::string Binder::Get(const std::string& key) const {
     return std::string();
 }
 
+void Binder::Unbind(const std::string& key) {
+    bindings_.erase(key);
+}
+
 }
 }

--- a/StrangeIoC_CPP/framework/binding/Binder.h
+++ b/StrangeIoC_CPP/framework/binding/Binder.h
@@ -16,6 +16,7 @@ public:
     std::shared_ptr<Binding> Bind(const std::string& key);
     void Register(const Binding& binding);
     std::string Get(const std::string& key) const;
+    void Unbind(const std::string& key);
 };
 
 }

--- a/StrangeIoC_CPP/framework/dispatcher/EventDispatcher.h
+++ b/StrangeIoC_CPP/framework/dispatcher/EventDispatcher.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 #include <string>
+#include <algorithm>
 
 namespace strange {
 namespace framework {
@@ -15,6 +16,24 @@ public:
     void AddListener(const std::string& type, Callback cb) {
         listeners_[type].push_back(cb);
     }
+
+    void AddOnce(const std::string& type, Callback cb) {
+        once_listeners_[type].push_back(cb);
+    }
+
+    void RemoveListener(const std::string& type, Callback cb) {
+        auto remove_cb = [&](std::vector<Callback>& list){
+            list.erase(std::remove_if(list.begin(), list.end(),
+                [&](const Callback& existing){
+                    return existing.target<void()>() == cb.target<void()>();
+                }), list.end());
+        };
+        auto it = listeners_.find(type);
+        if (it != listeners_.end()) remove_cb(it->second);
+        it = once_listeners_.find(type);
+        if (it != once_listeners_.end()) remove_cb(it->second);
+    }
+
     void Dispatch(const std::string& type) {
         auto it = listeners_.find(type);
         if (it != listeners_.end()) {
@@ -22,9 +41,17 @@ public:
                 cb();
             }
         }
+        it = once_listeners_.find(type);
+        if (it != once_listeners_.end()) {
+            for (auto& cb : it->second) {
+                cb();
+            }
+            once_listeners_.erase(it);
+        }
     }
 private:
     std::unordered_map<std::string, std::vector<Callback>> listeners_;
+    std::unordered_map<std::string, std::vector<Callback>> once_listeners_;
 };
 
 }

--- a/StrangeIoC_CPP/framework/injector/Injector.h
+++ b/StrangeIoC_CPP/framework/injector/Injector.h
@@ -27,6 +27,16 @@ public:
         return nullptr;
     }
 
+    template<typename T>
+    void Unbind() {
+        creators_.erase(std::type_index(typeid(T)));
+    }
+
+    template<typename T>
+    bool Has() const {
+        return creators_.find(std::type_index(typeid(T))) != creators_.end();
+    }
+
 private:
     std::unordered_map<std::type_index, std::function<std::shared_ptr<void>()>> creators_;
 };

--- a/StrangeIoC_CPP/framework/signal/Signal.h
+++ b/StrangeIoC_CPP/framework/signal/Signal.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <vector>
+#include <algorithm>
 
 namespace strange {
 namespace framework {
@@ -11,14 +12,36 @@ template<typename... Args>
 class Signal {
 public:
     using Callback = std::function<void(Args...)>;
+
     void AddListener(const Callback& cb) { listeners_.push_back(cb); }
+
+    void AddOnce(const Callback& cb) { once_listeners_.push_back(cb); }
+
+    void RemoveListener(const Callback& cb) {
+        auto remove_cb = [&](std::vector<Callback>& list){
+            list.erase(std::remove_if(list.begin(), list.end(),
+                [&](const Callback& existing){
+                    return existing.target_type() == cb.target_type() &&
+                           existing.template target<void(Args...)>() == cb.template target<void(Args...)>();
+                }), list.end());
+        };
+        remove_cb(listeners_);
+        remove_cb(once_listeners_);
+    }
+
     void Dispatch(Args... args) {
         for (auto& cb : listeners_) {
             cb(args...);
         }
+        for (auto& cb : once_listeners_) {
+            cb(args...);
+        }
+        once_listeners_.clear();
     }
+
 private:
     std::vector<Callback> listeners_;
+    std::vector<Callback> once_listeners_;
 };
 
 }

--- a/StrangeIoC_CPP/tests/main.cpp
+++ b/StrangeIoC_CPP/tests/main.cpp
@@ -2,6 +2,7 @@
 #include "../framework/binding/Binder.h"
 #include "../framework/signal/Signal.h"
 #include "../framework/injector/Injector.h"
+#include "../framework/dispatcher/EventDispatcher.h"
 
 using namespace strange::framework;
 
@@ -12,19 +13,38 @@ int main() {
     binding->To("value");
     binder.Register(*binding);
     assert(binder.Get("test") == "value");
+    binder.Unbind("test");
+    assert(binder.Get("test").empty());
 
     // Test Signal
     Signal<int> sig;
     int val = 0;
-    sig.AddListener([&](int v){ val = v; });
-    sig.Dispatch(42);
+    auto listener = [&](int v){ val = v; };
+    sig.AddListener(listener);
+    sig.AddOnce([&](int v){ val = v + 1; });
+    sig.Dispatch(41);
     assert(val == 42);
+    sig.RemoveListener(listener);
 
     // Test Injector
     Injector inj;
     inj.Bind<int>([](){ return std::make_shared<int>(7); });
+    assert(inj.Has<int>());
     auto instance = inj.Get<int>();
     assert(instance && *instance == 7);
+    inj.Unbind<int>();
+    assert(!inj.Has<int>());
+
+    // Test EventDispatcher
+    EventDispatcher disp;
+    bool called = false;
+    disp.AddListener("go", [&](){ called = true; });
+    disp.AddOnce("go", [&](){ called = true; });
+    disp.Dispatch("go");
+    assert(called);
+    called = false;
+    disp.Dispatch("go");
+    assert(called);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- extend C++ Signal with AddOnce and RemoveListener support
- extend EventDispatcher with AddOnce, RemoveListener and once dispatch
- add Unbind method to Binder
- add Unbind and Has helpers to Injector
- cover new features with unit tests

## Testing
- `cmake ../StrangeIoC_CPP`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68406a38d8408324a2cb0bd81d583f14