### PR TITLE
Add NUnit tests for Pool<T>

### DIFF
--- a/PoolLib/PoolLib.csproj
+++ b/PoolLib/PoolLib.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableDefaultItems>false</EnableDefaultItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../StrangeIoC/framework/pool/**/*.cs" />
+    <Compile Include="../StrangeIoC/framework/binding/**/*.cs" />
+    <Compile Include="../StrangeIoC/framework/injector/**/*.cs" />
+    <Compile Include="../StrangeIoC/framework/reflector/**/*.cs" />
+    <Compile Include="UnityEngine/Debug.cs" />
+    <Compile Remove="Class1.cs" />
+  </ItemGroup>
+
+</Project>

--- a/PoolLib/UnityEngine/Debug.cs
+++ b/PoolLib/UnityEngine/Debug.cs
@@ -1,0 +1,8 @@
+namespace UnityEngine
+{
+    public static class Debug
+    {
+        public static void Log(object message) {}
+        public static void LogError(object message) {}
+    }
+}

--- a/Tests/GlobalUsings.cs
+++ b/Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/Tests/PoolTests.cs
+++ b/Tests/PoolTests.cs
@@ -1,0 +1,64 @@
+using NUnit.Framework;
+using strange.extensions.pool.impl;
+using strange.extensions.pool.api;
+using strange.framework.api;
+
+namespace Tests;
+
+class TestObject : IPoolable
+{
+    public bool Restored { get; private set; }
+    public void Restore() => Restored = true;
+    public void Retain() { }
+    public void Release() { }
+    public bool retain { get; private set; }
+}
+
+class SimpleProvider : IInstanceProvider
+{
+    public T GetInstance<T>() => (T)System.Activator.CreateInstance(typeof(T));
+    public object GetInstance(System.Type key) => System.Activator.CreateInstance(key);
+}
+
+public class PoolTests
+{
+    Pool<TestObject> pool = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        pool = new Pool<TestObject>();
+        pool.instanceProvider = new SimpleProvider();
+    }
+
+    [Test]
+    public void GetInstanceReturnsNewObjectWhenEmpty()
+    {
+        var obj = pool.GetInstance();
+        Assert.NotNull(obj);
+        Assert.AreEqual(0, pool.available);
+    }
+
+    [Test]
+    public void ReturnInstanceRestoresAndStoresObject()
+    {
+        var obj = pool.GetInstance();
+        pool.ReturnInstance(obj);
+        Assert.IsTrue(obj.Restored);
+        Assert.AreEqual(1, pool.available);
+    }
+
+    [Test]
+    public void OverflowReturnsNullOrThrows()
+    {
+        pool.size = 1;
+        pool.overflowBehavior = PoolOverflowBehavior.IGNORE;
+        var first = pool.GetInstance();
+        var second = pool.GetInstance();
+        Assert.IsNull(second);
+        pool.ReturnInstance(first);
+        pool.overflowBehavior = PoolOverflowBehavior.EXCEPTION;
+        pool.GetInstance();
+        Assert.Throws<PoolException>(() => pool.GetInstance());
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../PoolLib/PoolLib.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- set up a small library project for pool classes
- add a stub `UnityEngine.Debug` for building without Unity
- create NUnit test project for `Pool<T>` behavior
- cover getting, returning, and overflow logic

## Testing
- `dotnet test Tests/Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68406696a93c8324978fb7391e2f7c54